### PR TITLE
Xenial   lp 1884738

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+pulseaudio (1:8.0-1ubports8) xenial; urgency=medium
+
+ * Import changes from Ubuntu xenial from 1:8.0-0ubuntu3.13 to
+   1:8.0-0ubuntu3.14, but not 0ubuntu3.12 to 0ubuntu3.13.
+  * SECURITY UPDATE: potential double-free in the Bluez 5 module (LP: #1884738)
+    - d/p/0511-bluetooth-bluez5-fix-double-free-in-pa__init.patch:
+      Only free modargs once in each of
+      src/modules/bluetooth/module-bluez5-device.c and
+      src/modules/bluetooth/module-bluez5-discover.c, patch thanks to Ratchanan
+      Srirattanamet.
+    - d/p/0512-bluetooth-bluez5-fix-double-free-2.patch: Initialize pointer
+      before dereferencing in fail condition.
+    - CVE-2020-15710
+
+ -- Dalton Durst <dalton@ubports.com>  Thu, 17 Sep 2020 18:21:32 -0500
+
 pulseaudio (1:8.0-1ubports7) xenial; urgency=medium
 
   * Release to devel channel.

--- a/debian/patches/0511-bluetooth-bluez5-fix-double-free-in-pa__init.patch
+++ b/debian/patches/0511-bluetooth-bluez5-fix-double-free-in-pa__init.patch
@@ -1,0 +1,34 @@
+Description: bluetooth: bluez5: fix double free in pa__init
+ The SCO-over-PCM patch creates code paths in pa__init() that will free
+ the modargs twice in its failure handler and in pa__done() called from
+ that handler. Add a check in the failure handler to prevent freeing
+ modargs if it's going to be freed in pa__done().
+Author: Ratchanan Srirattanamet <ratchanan@ubports.com>
+Forwarded: no
+Last-Update: 2020-06-23
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/src/modules/bluetooth/module-bluez5-device.c
++++ b/src/modules/bluetooth/module-bluez5-device.c
+@@ -2552,7 +2552,8 @@ off:
+ 
+ fail:
+ 
+-    if (ma)
++    /* u->modargs is also freed in pa__done(). Prevent double-free. */
++    if (ma && !u->modargs)
+         pa_modargs_free(ma);
+ 
+     pa__done(m);
+--- a/src/modules/bluetooth/module-bluez5-discover.c
++++ b/src/modules/bluetooth/module-bluez5-discover.c
+@@ -170,7 +170,8 @@ int pa__init(pa_module *m) {
+     return 0;
+ 
+ fail:
+-    if (ma)
++    /* u->modargs is also freed in pa__done(). Prevent double-free. */
++    if (ma && !u->modargs)
+         pa_modargs_free(ma);
+     pa__done(m);
+     return -1;

--- a/debian/patches/0512-bluetooth-bluez5-fix-double-free-2.patch
+++ b/debian/patches/0512-bluetooth-bluez5-fix-double-free-2.patch
@@ -1,0 +1,28 @@
+Description: Initialize u to NULL 
+ Modify 0511-bluetooth-bluez5-fix-double-free-in-pa__init.patch to initialize
+ and reference initialized u pointer.
+Author: Avital Ostromich <avital.ostromich@canonical.com>
+Origin: vendor
+Last-Update: 2020-09-02
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/src/modules/bluetooth/module-bluez5-discover.c
++++ b/src/modules/bluetooth/module-bluez5-discover.c
+@@ -128,7 +128,7 @@ const char *default_headset_backend = "o
+ #endif
+ 
+ int pa__init(pa_module *m) {
+-    struct userdata *u;
++    struct userdata *u = NULL;
+     pa_modargs *ma;
+     const char *headset_str;
+     int headset_backend;
+@@ -171,7 +171,7 @@ int pa__init(pa_module *m) {
+ 
+ fail:
+     /* u->modargs is also freed in pa__done(). Prevent double-free. */
+-    if (ma && !u->modargs)
++    if (ma && !u)
+         pa_modargs_free(ma);
+     pa__done(m);
+     return -1;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -48,6 +48,8 @@
 0508-bluetooth-bluez5-add-guards-to-prevent-HFP-and-HSP-c.patch
 0509-bluetooth-bluez5-don-t-reactivate-default-profile-wh.patch
 0510-Further-fixes-for-HFP-A2DP-with-BlueZ-5.x.patch
+0511-bluetooth-bluez5-fix-double-free-in-pa__init.patch
+0512-bluetooth-bluez5-fix-double-free-2.patch
 
 # Ubuntu touch: add support for Android 5.x
 0600-droid-sync-with-upstream-for-Android-5-support-and-b.patch


### PR DESCRIPTION
Ratchanan Srirattanamet discovered that an Ubuntu-specific patch caused PulseAudio to incorrectly handle memory under certain error conditions in the Bluez 5 module. An attacker could use this issue to cause PulseAudio to crash, resulting in a denial of service, or possibly execute arbitrary code.

https://ubuntu.com/security/notices/USN-4519-1
https://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15710.html